### PR TITLE
Add Quarkus REST extension for template endpoint

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -82,6 +82,10 @@
       <artifactId>quarkus-hibernate-orm-panache</artifactId>
     </dependency>
     <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-rest-jackson</artifactId>
+    </dependency>
+    <dependency>
       <groupId>com.nimbusds</groupId>
       <artifactId>nimbus-jose-jwt</artifactId>
       <version>9.37.3</version>


### PR DESCRIPTION
## Summary
- enable REST resources by adding quarkus-rest-jackson

## Testing
- ⚠️ `mvn test` *(network unreachable while resolving Maven dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_689fb61550e8832d99e702621f06c8cd