### PR TITLE
feat: support system properties in k8s secret resolver

### DIFF
--- a/src/main/java/io/redhat/na/ssp/tasktally/secret/KubernetesSecretResolver.java
+++ b/src/main/java/io/redhat/na/ssp/tasktally/secret/KubernetesSecretResolver.java
@@ -20,8 +20,11 @@ public class KubernetesSecretResolver implements SecretResolver {
   private final Path basePath;
 
   public KubernetesSecretResolver() {
-    String env = System.getenv().getOrDefault("K8S_SECRET_BASE_PATH", "/var/run/secrets");
-    this.basePath = Paths.get(env);
+    String base = System.getProperty("k8s.secret.base.path");
+    if (base == null || base.isBlank()) {
+      base = System.getenv().getOrDefault("K8S_SECRET_BASE_PATH", "/var/run/secrets");
+    }
+    this.basePath = Paths.get(base);
   }
 
   // Package-private constructor for tests
@@ -54,6 +57,9 @@ public class KubernetesSecretResolver implements SecretResolver {
 
     String envKey = (name + "_" + key).toUpperCase(Locale.ROOT).replace('-', '_').replace('.', '_');
     String envVal = System.getenv(envKey);
+    if (envVal == null) {
+      envVal = System.getProperty("env." + envKey);
+    }
     if (envVal != null) {
       return envVal.getBytes(StandardCharsets.UTF_8);
     }

--- a/src/test/java/io/redhat/na/ssp/tasktally/github/ssh/TaskTallySshdSessionFactoryTest.java
+++ b/src/test/java/io/redhat/na/ssp/tasktally/github/ssh/TaskTallySshdSessionFactoryTest.java
@@ -16,7 +16,7 @@ class TaskTallySshdSessionFactoryTest {
   void buildsFactoryFromInMemoryKey() throws Exception {
     // Ensure EdDSA provider is registered
     java.security.Security.addProvider(new net.i2p.crypto.eddsa.EdDSASecurityProvider());
-    java.security.KeyPairGenerator gen = java.security.KeyPairGenerator.getInstance("Ed25519", "EdDSA");
+    java.security.KeyPairGenerator gen = java.security.KeyPairGenerator.getInstance("EdDSA", "EdDSA");
     gen.initialize(new net.i2p.crypto.eddsa.spec.EdDSAGenParameterSpec("Ed25519"));
     KeyPair kp = gen.generateKeyPair();
     ByteArrayOutputStream bos = new ByteArrayOutputStream();


### PR DESCRIPTION
## Summary
- allow `KubernetesSecretResolver` to read base path and secrets from system properties
- align SSH session factory test with EdDSA provider API

## Testing
- `mvn -q -e test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689fe764eea4832d895d681374d4866e