### PR TITLE
feat: add template management

### DIFF
--- a/src/main/java/io/redhat/na/ssp/tasktally/api/TemplateResource.java
+++ b/src/main/java/io/redhat/na/ssp/tasktally/api/TemplateResource.java
@@ -1,0 +1,62 @@
+package io.redhat.na.ssp.tasktally.api;
+
+import io.redhat.na.ssp.tasktally.api.dto.TemplateDto;
+import io.redhat.na.ssp.tasktally.model.Template;
+import io.redhat.na.ssp.tasktally.service.TemplateService;
+import jakarta.inject.Inject;
+import jakarta.validation.Valid;
+import jakarta.ws.rs.*;
+import jakarta.ws.rs.core.MediaType;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Path("/api/users/{userId}/templates")
+@Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
+public class TemplateResource {
+
+  @Inject TemplateService service;
+
+  @GET
+  public List<TemplateDto> list(@PathParam("userId") String userId) {
+    return service.list(userId).stream().map(this::toDto).collect(Collectors.toList());
+  }
+
+  @POST
+  public TemplateDto create(@PathParam("userId") String userId, @Valid TemplateDto dto) {
+    Template tmpl = fromDto(dto);
+    Template saved = service.create(userId, tmpl);
+    return toDto(saved);
+  }
+
+  @PUT
+  @Path("/{id}")
+  public TemplateDto update(@PathParam("userId") String userId, @PathParam("id") Long id, @Valid TemplateDto dto) {
+    Template tmpl = fromDto(dto);
+    Template updated = service.update(userId, id, tmpl);
+    return toDto(updated);
+  }
+
+  @DELETE
+  @Path("/{id}")
+  public void delete(@PathParam("userId") String userId, @PathParam("id") Long id) {
+    service.delete(userId, id);
+  }
+
+  private TemplateDto toDto(Template t) {
+    TemplateDto dto = new TemplateDto();
+    dto.id = t.id;
+    dto.name = t.name;
+    dto.description = t.description;
+    dto.repositoryUrl = t.repositoryUrl;
+    return dto;
+  }
+
+  private Template fromDto(TemplateDto dto) {
+    Template t = new Template();
+    t.name = dto.name;
+    t.description = dto.description;
+    t.repositoryUrl = dto.repositoryUrl;
+    return t;
+  }
+}

--- a/src/main/java/io/redhat/na/ssp/tasktally/api/dto/TemplateDto.java
+++ b/src/main/java/io/redhat/na/ssp/tasktally/api/dto/TemplateDto.java
@@ -1,0 +1,12 @@
+package io.redhat.na.ssp.tasktally.api.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public class TemplateDto {
+  public Long id;
+  @NotBlank
+  public String name;
+  public String description;
+  @NotBlank
+  public String repositoryUrl;
+}

--- a/src/main/java/io/redhat/na/ssp/tasktally/model/Template.java
+++ b/src/main/java/io/redhat/na/ssp/tasktally/model/Template.java
@@ -1,0 +1,51 @@
+package io.redhat.na.ssp.tasktally.model;
+
+import io.quarkus.hibernate.orm.panache.PanacheEntityBase;
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotBlank;
+import java.time.Instant;
+
+@Entity
+@Table(name = "templates")
+public class Template extends PanacheEntityBase {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  public Long id;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "user_preferences_id", nullable = false)
+  public UserPreferences userPreferences;
+
+  @Column(nullable = false)
+  @NotBlank
+  public String name;
+
+  @Column
+  public String description;
+
+  @Column(name = "repository_url", nullable = false, unique = true)
+  @NotBlank
+  public String repositoryUrl;
+
+  @Column(name = "created_at")
+  public Instant createdAt;
+
+  @Column(name = "updated_at")
+  public Instant updatedAt;
+
+  @PrePersist
+  public void prePersist() {
+    if (createdAt == null) {
+      createdAt = Instant.now();
+    }
+    if (updatedAt == null) {
+      updatedAt = Instant.now();
+    }
+  }
+
+  @PreUpdate
+  public void preUpdate() {
+    updatedAt = Instant.now();
+  }
+}

--- a/src/main/java/io/redhat/na/ssp/tasktally/repo/TemplateRepository.java
+++ b/src/main/java/io/redhat/na/ssp/tasktally/repo/TemplateRepository.java
@@ -1,0 +1,19 @@
+package io.redhat.na.ssp.tasktally.repo;
+
+import io.quarkus.hibernate.orm.panache.PanacheRepository;
+import io.redhat.na.ssp.tasktally.model.Template;
+import jakarta.enterprise.context.ApplicationScoped;
+import java.util.List;
+import java.util.Optional;
+
+@ApplicationScoped
+public class TemplateRepository implements PanacheRepository<Template> {
+
+  public List<Template> listByUser(Long userPreferencesId) {
+    return list("userPreferences.id", userPreferencesId);
+  }
+
+  public Optional<Template> findByUserAndId(Long userPreferencesId, Long id) {
+    return find("userPreferences.id = ?1 and id = ?2", userPreferencesId, id).firstResultOptional();
+  }
+}

--- a/src/main/java/io/redhat/na/ssp/tasktally/service/TemplateService.java
+++ b/src/main/java/io/redhat/na/ssp/tasktally/service/TemplateService.java
@@ -1,0 +1,80 @@
+package io.redhat.na.ssp.tasktally.service;
+
+import io.redhat.na.ssp.tasktally.model.Template;
+import io.redhat.na.ssp.tasktally.model.UserPreferences;
+import io.redhat.na.ssp.tasktally.repo.TemplateRepository;
+import io.redhat.na.ssp.tasktally.repo.UserPreferencesRepository;
+import io.redhat.na.ssp.tasktally.github.ssh.SshGitService;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.transaction.Transactional;
+import jakarta.ws.rs.NotFoundException;
+import org.eclipse.jgit.api.errors.GitAPIException;
+import org.yaml.snakeyaml.Yaml;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@ApplicationScoped
+public class TemplateService {
+
+  @Inject TemplateRepository templateRepo;
+  @Inject UserPreferencesRepository userRepo;
+  @Inject SshGitService gitService;
+
+  private final Yaml yaml = new Yaml();
+
+  @Transactional
+  public List<Template> list(String userId) {
+    UserPreferences up = userRepo.findByUserId(userId).orElseThrow(NotFoundException::new);
+    return templateRepo.listByUser(up.id);
+  }
+
+  @Transactional
+  public Template create(String userId, Template tmpl) {
+    UserPreferences up = userRepo.findByUserId(userId).orElseThrow(NotFoundException::new);
+    tmpl.id = null;
+    tmpl.userPreferences = up;
+    templateRepo.persist(tmpl);
+    syncRepo(tmpl);
+    return tmpl;
+  }
+
+  @Transactional
+  public Template update(String userId, Long templateId, Template incoming) {
+    UserPreferences up = userRepo.findByUserId(userId).orElseThrow(NotFoundException::new);
+    Template existing = templateRepo.findByUserAndId(up.id, templateId).orElseThrow(NotFoundException::new);
+    existing.name = incoming.name;
+    existing.description = incoming.description;
+    existing.repositoryUrl = incoming.repositoryUrl;
+    templateRepo.persist(existing);
+    syncRepo(existing);
+    return existing;
+  }
+
+  @Transactional
+  public void delete(String userId, Long templateId) {
+    UserPreferences up = userRepo.findByUserId(userId).orElseThrow(NotFoundException::new);
+    templateRepo.findByUserAndId(up.id, templateId).orElseThrow(NotFoundException::new);
+    templateRepo.delete("userPreferences = ?1 and id = ?2", up, templateId);
+  }
+
+  private void syncRepo(Template tmpl) {
+    try {
+      Path work = Files.createTempDirectory("tmpl-repo");
+      Path repo = gitService.cloneShallow(tmpl.repositoryUrl, "main", work, null);
+      Map<String, Object> data = new HashMap<>();
+      data.put("name", tmpl.name);
+      data.put("description", tmpl.description);
+      Path file = repo.resolve("template.yml");
+      Files.writeString(file, yaml.dump(data));
+      gitService.commitAndPush(repo, "TaskTally", "noreply@tasktally.local", "Update template", null);
+    } catch (IOException | GitAPIException e) {
+      throw new IllegalStateException("Failed to sync template repository", e);
+    }
+  }
+}

--- a/src/main/resources/db/migration/V2__create_templates.sql
+++ b/src/main/resources/db/migration/V2__create_templates.sql
@@ -1,0 +1,17 @@
+-- templates table for user project templates
+CREATE TABLE IF NOT EXISTS templates (
+  id BIGSERIAL PRIMARY KEY,
+  user_preferences_id BIGINT NOT NULL REFERENCES user_preferences(id) ON DELETE CASCADE,
+  name TEXT NOT NULL,
+  description TEXT,
+  repository_url TEXT NOT NULL UNIQUE,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_templates_user ON templates(user_preferences_id);
+
+DROP TRIGGER IF EXISTS set_timestamp_templates ON templates;
+CREATE TRIGGER set_timestamp_templates
+BEFORE UPDATE ON templates
+FOR EACH ROW EXECUTE FUNCTION trg_set_timestamp();

--- a/src/test/java/io/redhat/na/ssp/tasktally/repo/TemplateRepositoryTest.java
+++ b/src/test/java/io/redhat/na/ssp/tasktally/repo/TemplateRepositoryTest.java
@@ -1,0 +1,32 @@
+package io.redhat.na.ssp.tasktally.repo;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.redhat.na.ssp.tasktally.model.Template;
+import io.redhat.na.ssp.tasktally.model.UserPreferences;
+import jakarta.inject.Inject;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+@QuarkusTest
+public class TemplateRepositoryTest {
+
+  @Inject TemplateRepository repo;
+  @Inject UserPreferencesRepository userRepo;
+
+  @Test
+  public void testListByUser() {
+    UserPreferences up = new UserPreferences();
+    up.userId = "u2";
+    userRepo.persist(up);
+
+    Template t = new Template();
+    t.userPreferences = up;
+    t.name = "T";
+    t.repositoryUrl = "git@example.com:repo2.git";
+    repo.persist(t);
+
+    List<Template> list = repo.listByUser(up.id);
+    assertEquals(1, list.size());
+  }
+}

--- a/src/test/java/io/redhat/na/ssp/tasktally/service/TemplateServiceTest.java
+++ b/src/test/java/io/redhat/na/ssp/tasktally/service/TemplateServiceTest.java
@@ -1,0 +1,68 @@
+package io.redhat.na.ssp.tasktally.service;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.when;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.mockito.InjectMock;
+import io.redhat.na.ssp.tasktally.github.ssh.SshGitService;
+import io.redhat.na.ssp.tasktally.model.Template;
+import io.redhat.na.ssp.tasktally.model.UserPreferences;
+import io.redhat.na.ssp.tasktally.repo.TemplateRepository;
+import io.redhat.na.ssp.tasktally.repo.UserPreferencesRepository;
+import jakarta.inject.Inject;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.eclipse.jgit.api.errors.GitAPIException;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@QuarkusTest
+public class TemplateServiceTest {
+
+  @Inject TemplateService service;
+  @Inject UserPreferencesRepository userRepo;
+  @Inject TemplateRepository templateRepo;
+
+  @InjectMock SshGitService gitService;
+
+  @BeforeEach
+  public void setup() throws Exception {
+    UserPreferences up = new UserPreferences();
+    up.userId = "u1";
+    userRepo.persist(up);
+
+    when(gitService.cloneShallow(any(), any(), any(Path.class), any()))
+        .thenAnswer(invocation -> {
+          Path dir = invocation.getArgument(2);
+          Files.createDirectories(dir);
+          return dir;
+        });
+    doNothing().when(gitService).commitAndPush(any(Path.class), any(), any(), any(), any());
+  }
+
+  @Test
+  public void testCreateUpdateDelete() throws IOException, GitAPIException {
+    Template t = new Template();
+    t.name = "T1";
+    t.description = "desc";
+    t.repositoryUrl = "git@example.com:repo.git";
+    Template saved = service.create("u1", t);
+    assertNotNull(saved.id);
+
+    Template upd = new Template();
+    upd.name = "T1b";
+    upd.description = "desc2";
+    upd.repositoryUrl = "git@example.com:repo.git";
+    Template updated = service.update("u1", saved.id, upd);
+    assertEquals("T1b", updated.name);
+
+    service.delete("u1", saved.id);
+    assertTrue(templateRepo.listAll().isEmpty());
+  }
+}


### PR DESCRIPTION
## Summary
- add `Template` entity and repository
- implement service and REST resource for template CRUD
- add migration for templates table and basic tests

## Testing
- `mvn -q test` *(fails: Could not transfer artifact io.quarkus.platform:quarkus-bom:pom:3.25.3 from/to central - Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a111888358832d9ffa929ad84c06dd