### PR TITLE
feat(ssh): add user ssh key management API

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,34 +84,28 @@ curl -X POST -H 'X-User-Id: u1' -H 'Content-Type: application/json' \
 
 ## Using SSH Keys
 
-Task‑tally can upload or generate SSH keys and keep the sensitive bytes in a
+Task‑tally can upload SSH keys and keep the sensitive bytes in a
 secret store. Postgres stores only references.
 
 1. **Upload an existing key**
    ```bash
-   curl -X POST $BASE/api/preferences/me/ssh-keys \
+   curl -X POST $BASE/api/users/user123/ssh-keys \
      -H "Content-Type: application/json" -H "X-User-Id: user123" \
      -d '{"name":"my-gh-key","provider":"github",\
           "privateKeyPem":"-----BEGIN OPENSSH PRIVATE KEY-----\\n...\\n-----END OPENSSH PRIVATE KEY-----\\n",\
           "knownHosts":"github.com ssh-ed25519 AAAA...\\n"}'
    ```
-2. **Generate a new key server side**
-   ```bash
-   curl -X POST $BASE/api/preferences/me/ssh-keys/generate \
-     -H "Content-Type: application/json" -H "X-User-Id: user123" \
-     -d '{"name":"gen-key","provider":"github"}'
-   ```
-3. **Register the public key** with GitHub/GitLab as a deploy key (allow write).
-4. **Provide known_hosts**
+2. **Register the public key** with GitHub/GitLab as a deploy key (allow write).
+3. **Provide known_hosts**
    ```bash
    ssh-keyscan -t ed25519 github.com >> known_hosts
    ```
-5. **Validate and delete**
+4. **Validate and delete**
    ```bash
    curl -X POST $BASE/api/git/ssh/validate -H "Content-Type: application/json" \
      -H "X-User-Id: user123" -d '{"provider":"github","owner":"acme","repo":"templates","branch":"main","credentialName":"my-gh-key"}'
 
-   curl -X DELETE $BASE/api/preferences/me/ssh-keys/my-gh-key -H "X-User-Id: user123"
+   curl -X DELETE $BASE/api/users/user123/ssh-keys/my-gh-key -H "X-User-Id: user123"
    ```
 The backend loads private key material into memory only when performing Git
 operations and never stores raw secrets in Postgres.

--- a/src/main/java/io/redhat/na/ssp/tasktally/api/CredentialDto.java
+++ b/src/main/java/io/redhat/na/ssp/tasktally/api/CredentialDto.java
@@ -1,0 +1,13 @@
+package io.redhat.na.ssp.tasktally.api;
+
+import java.time.Instant;
+
+public class CredentialDto {
+  public String name;
+  public String provider;
+  public String scope;
+  public String secretRef;
+  public String knownHostsRef;
+  public String passphraseRef;
+  public Instant createdAt;
+}

--- a/src/main/java/io/redhat/na/ssp/tasktally/api/GitSshResource.java
+++ b/src/main/java/io/redhat/na/ssp/tasktally/api/GitSshResource.java
@@ -35,7 +35,7 @@ public class GitSshResource {
     CredentialRef cred = store.find(userId, req.credentialName).orElse(null);
     if (cred == null) {
       LOG.warnf("Credential %s not found for user %s", req.credentialName, userId);
-      return Response.status(Response.Status.BAD_REQUEST).entity(new ValidateResult(false, "Credential not found"))
+      return Response.status(Response.Status.NOT_FOUND).entity(new ValidateResult(false, "Credential not found"))
           .build();
     }
     String uri = "git@" + req.provider + ".com:" + req.owner + "/" + req.repo + ".git";

--- a/src/main/java/io/redhat/na/ssp/tasktally/api/SshKeyCreateRequest.java
+++ b/src/main/java/io/redhat/na/ssp/tasktally/api/SshKeyCreateRequest.java
@@ -1,0 +1,9 @@
+package io.redhat.na.ssp.tasktally.api;
+
+public class SshKeyCreateRequest {
+  public String name;
+  public String provider;
+  public String privateKeyPem;
+  public String knownHosts;
+  public String passphrase;
+}

--- a/src/main/java/io/redhat/na/ssp/tasktally/api/SshKeysResource.java
+++ b/src/main/java/io/redhat/na/ssp/tasktally/api/SshKeysResource.java
@@ -1,0 +1,88 @@
+package io.redhat.na.ssp.tasktally.api;
+
+import io.redhat.na.ssp.tasktally.model.CredentialRef;
+import io.redhat.na.ssp.tasktally.service.SshKeyService;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.DELETE;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.HeaderParam;
+import jakarta.ws.rs.NotFoundException;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.eclipse.microprofile.openapi.annotations.Operation;
+import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
+import org.jboss.logging.Logger;
+
+@Path("/api/users/{userId}/ssh-keys")
+@Consumes(MediaType.APPLICATION_JSON)
+@Produces(MediaType.APPLICATION_JSON)
+public class SshKeysResource {
+  private static final Logger LOG = Logger.getLogger(SshKeysResource.class);
+  @Inject
+  SshKeyService service;
+
+  private void authorize(String pathUser, String headerUser) {
+    if (headerUser == null || headerUser.isBlank() || !headerUser.equals(pathUser)) {
+      throw new WebApplicationException("forbidden", Response.Status.FORBIDDEN);
+    }
+  }
+
+  private CredentialDto toDto(CredentialRef cred) {
+    CredentialDto dto = new CredentialDto();
+    dto.name = cred.name;
+    dto.provider = cred.provider;
+    dto.scope = cred.scope;
+    dto.secretRef = cred.secretRef;
+    dto.knownHostsRef = cred.knownHostsRef;
+    dto.passphraseRef = cred.passphraseRef;
+    dto.createdAt = cred.createdAt;
+    return dto;
+  }
+
+  @GET
+  @Operation(summary = "List SSH keys for user")
+  @APIResponse(responseCode = "200", description = "List of SSH credential references")
+  public List<CredentialDto> list(@PathParam("userId") String userId, @HeaderParam("X-User-Id") String header) {
+    authorize(userId, header);
+    return service.list(userId).stream().map(this::toDto).collect(Collectors.toList());
+  }
+
+  @POST
+  @Operation(summary = "Create SSH key for user")
+  @APIResponse(responseCode = "201", description = "Created")
+  public Response create(@PathParam("userId") String userId, @HeaderParam("X-User-Id") String header,
+      SshKeyCreateRequest req) {
+    authorize(userId, header);
+    try {
+      CredentialRef cred = service.create(userId, req);
+      return Response.status(Response.Status.CREATED).entity(toDto(cred)).build();
+    } catch (IllegalStateException e) {
+      throw new WebApplicationException(e.getMessage(), Response.Status.CONFLICT);
+    } catch (IllegalArgumentException e) {
+      throw new WebApplicationException(e.getMessage(), Response.Status.BAD_REQUEST);
+    }
+  }
+
+  @DELETE
+  @Path("/{name}")
+  @Operation(summary = "Delete SSH key")
+  @APIResponse(responseCode = "204", description = "Deleted")
+  public Response delete(@PathParam("userId") String userId, @HeaderParam("X-User-Id") String header,
+      @PathParam("name") String name) {
+    authorize(userId, header);
+    try {
+      service.delete(userId, name);
+      return Response.noContent().build();
+    } catch (IllegalArgumentException e) {
+      throw new NotFoundException();
+    }
+  }
+}

--- a/src/main/java/io/redhat/na/ssp/tasktally/service/CredentialStore.java
+++ b/src/main/java/io/redhat/na/ssp/tasktally/service/CredentialStore.java
@@ -2,6 +2,8 @@ package io.redhat.na.ssp.tasktally.service;
 
 import io.redhat.na.ssp.tasktally.model.CredentialRef;
 import jakarta.enterprise.context.ApplicationScoped;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
@@ -29,6 +31,23 @@ public class CredentialStore {
       LOG.warnf("Credential %s for user %s not found", name, userId);
     }
     return Optional.ofNullable(cred);
+  }
+
+  public List<CredentialRef> list(String userId) {
+    LOG.debugf("Listing credentials for user %s", userId);
+    List<CredentialRef> creds = new ArrayList<>();
+    String prefix = userId + ":";
+    for (Map.Entry<String, CredentialRef> e : store.entrySet()) {
+      if (e.getKey().startsWith(prefix)) {
+        creds.add(e.getValue());
+      }
+    }
+    return creds;
+  }
+
+  public void remove(String userId, String name) {
+    LOG.debugf("Removing credential %s for user %s", name, userId);
+    store.remove(key(userId, name));
   }
 
   private String key(String userId, String name) {

--- a/src/main/java/io/redhat/na/ssp/tasktally/service/SshKeyService.java
+++ b/src/main/java/io/redhat/na/ssp/tasktally/service/SshKeyService.java
@@ -1,0 +1,78 @@
+package io.redhat.na.ssp.tasktally.service;
+
+import io.redhat.na.ssp.tasktally.api.SshKeyCreateRequest;
+import io.redhat.na.ssp.tasktally.model.CredentialRef;
+import io.redhat.na.ssp.tasktally.secrets.SecretWriter;
+import io.redhat.na.ssp.tasktally.secrets.SshKeyValidator;
+import io.redhat.na.ssp.tasktally.secrets.SshSecretRefs;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+import org.jboss.logging.Logger;
+
+@ApplicationScoped
+public class SshKeyService {
+  private static final Logger LOG = Logger.getLogger(SshKeyService.class);
+  private static final Set<String> ALLOWED_PROVIDERS = Set.of("github", "gitlab");
+
+  @Inject
+  SecretWriter secretWriter;
+  @Inject
+  CredentialStore store;
+
+  public List<CredentialRef> list(String userId) {
+    return store.list(userId);
+  }
+
+  public CredentialRef create(String userId, SshKeyCreateRequest req) {
+    if (req == null) {
+      throw new IllegalArgumentException("request required");
+    }
+    String name = req.name != null ? req.name.trim() : null;
+    if (name == null || name.isEmpty()) {
+      throw new IllegalArgumentException("name is required");
+    }
+    if (store.find(userId, name).isPresent()) {
+      throw new IllegalStateException("credential already exists");
+    }
+    String provider = req.provider != null ? req.provider.trim().toLowerCase(Locale.ROOT) : null;
+    if (provider == null || !ALLOWED_PROVIDERS.contains(provider)) {
+      throw new IllegalArgumentException("provider must be github or gitlab");
+    }
+    byte[] priv = req.privateKeyPem != null ? req.privateKeyPem.getBytes(StandardCharsets.UTF_8) : null;
+    SshKeyValidator.validatePrivateKey(priv);
+    byte[] kh = req.knownHosts != null ? req.knownHosts.getBytes(StandardCharsets.UTF_8) : null;
+    SshKeyValidator.validateKnownHosts(kh);
+    char[] pp = req.passphrase != null ? req.passphrase.toCharArray() : null;
+    SshKeyValidator.validatePassphrase(pp);
+
+    SshSecretRefs refs = secretWriter.writeSshKey(userId, name, priv, null, pp, kh);
+
+    CredentialRef cred = new CredentialRef();
+    cred.name = name;
+    cred.provider = provider;
+    cred.scope = "write";
+    cred.secretRef = refs.privateKeyRef();
+    cred.knownHostsRef = refs.knownHostsRef();
+    cred.passphraseRef = refs.passphraseRef();
+    cred.createdAt = Instant.now();
+    store.put(userId, cred);
+    return cred;
+  }
+
+  public void delete(String userId, String name) {
+    CredentialRef cred = store.find(userId, name).orElseThrow(() -> new IllegalArgumentException("not found"));
+    try {
+      secretWriter.deleteByRef(cred.secretRef);
+      secretWriter.deleteByRef(cred.knownHostsRef);
+      secretWriter.deleteByRef(cred.passphraseRef);
+    } catch (Exception e) {
+      LOG.warn("Failed to delete secret", e);
+    }
+    store.remove(userId, name);
+  }
+}

--- a/src/test/java/io/redhat/na/ssp/tasktally/api/SshKeysResourceTest.java
+++ b/src/test/java/io/redhat/na/ssp/tasktally/api/SshKeysResourceTest.java
@@ -1,0 +1,64 @@
+package io.redhat.na.ssp.tasktally.api;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import io.quarkus.test.InjectMock;
+import io.quarkus.test.junit.QuarkusTest;
+import io.redhat.na.ssp.tasktally.secrets.SecretWriter;
+import io.redhat.na.ssp.tasktally.secrets.SshSecretRefs;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+@QuarkusTest
+public class SshKeysResourceTest {
+
+  @InjectMock
+  SecretWriter writer;
+
+  @BeforeEach
+  public void setup() {
+    when(writer.writeSshKey(any(), any(), any(), any(), any(), any()))
+        .thenReturn(new SshSecretRefs("kref", "href", null));
+  }
+
+  @Test
+  public void createListDelete() {
+    String body = "{\"name\":\"k1\",\"provider\":\"github\",\"privateKeyPem\":\"-----BEGIN OPENSSH PRIVATE KEY-----\\nAAA\\n-----END OPENSSH PRIVATE KEY-----\\n\",\"knownHosts\":\"github.com ssh-ed25519 AAAA\\n\"}";
+    given().header("X-User-Id", "u1").contentType("application/json").body(body)
+        .post("/api/users/u1/ssh-keys").then().statusCode(201)
+        .body("secretRef", equalTo("kref"));
+    given().header("X-User-Id", "u1").get("/api/users/u1/ssh-keys").then().statusCode(200)
+        .body("", hasSize(1));
+    given().header("X-User-Id", "u1").delete("/api/users/u1/ssh-keys/k1").then().statusCode(204);
+    given().header("X-User-Id", "u1").get("/api/users/u1/ssh-keys").then().statusCode(200)
+        .body("", hasSize(0));
+  }
+
+  @Test
+  public void duplicateName409() {
+    String body = "{\"name\":\"dup\",\"provider\":\"github\",\"privateKeyPem\":\"-----BEGIN OPENSSH PRIVATE KEY-----\\nAAA\\n-----END OPENSSH PRIVATE KEY-----\\n\"}";
+    given().header("X-User-Id", "u1").contentType("application/json").body(body)
+        .post("/api/users/u1/ssh-keys").then().statusCode(201);
+    given().header("X-User-Id", "u1").contentType("application/json").body(body)
+        .post("/api/users/u1/ssh-keys").then().statusCode(409);
+  }
+
+  @Test
+  public void oversizedKey400() {
+    String big = "A".repeat(11 * 1024);
+    String body = "{\"name\":\"big\",\"provider\":\"github\",\"privateKeyPem\":\"-----BEGIN OPENSSH PRIVATE KEY-----" + big + "-----END OPENSSH PRIVATE KEY-----\"}";
+    given().header("X-User-Id", "u1").contentType("application/json").body(body)
+        .post("/api/users/u1/ssh-keys").then().statusCode(400);
+  }
+
+  @Test
+  public void headerMismatch403() {
+    String body = "{\"name\":\"k2\",\"provider\":\"github\",\"privateKeyPem\":\"-----BEGIN OPENSSH PRIVATE KEY-----\\nAAA\\n-----END OPENSSH PRIVATE KEY-----\\n\"}";
+    given().header("X-User-Id", "u2").contentType("application/json").body(body)
+        .post("/api/users/u1/ssh-keys").then().statusCode(403);
+  }
+}

--- a/src/test/java/io/redhat/na/ssp/tasktally/service/SshKeyServiceTest.java
+++ b/src/test/java/io/redhat/na/ssp/tasktally/service/SshKeyServiceTest.java
@@ -1,0 +1,41 @@
+package io.redhat.na.ssp.tasktally.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.quarkus.test.InjectMock;
+import io.quarkus.test.junit.QuarkusTest;
+import io.redhat.na.ssp.tasktally.api.SshKeyCreateRequest;
+import io.redhat.na.ssp.tasktally.model.CredentialRef;
+import io.redhat.na.ssp.tasktally.secrets.SecretWriter;
+import io.redhat.na.ssp.tasktally.secrets.SshSecretRefs;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.Test;
+
+@QuarkusTest
+public class SshKeyServiceTest {
+
+  @Inject
+  SshKeyService service;
+  @Inject
+  CredentialStore store;
+  @InjectMock
+  SecretWriter writer;
+
+  @Test
+  public void createStoresCredential() {
+    when(writer.writeSshKey(any(), any(), any(), any(), any(), any()))
+        .thenReturn(new SshSecretRefs("ref1", "kh", null));
+    SshKeyCreateRequest req = new SshKeyCreateRequest();
+    req.name = "k1";
+    req.provider = "github";
+    req.privateKeyPem = "-----BEGIN OPENSSH PRIVATE KEY-----\nAAA\n-----END OPENSSH PRIVATE KEY-----\n";
+    req.knownHosts = "github.com ssh-ed25519 AAAA\n";
+    CredentialRef cred = service.create("u1", req);
+    assertEquals("ref1", cred.secretRef);
+    assertEquals(1, store.list("u1").size());
+    verify(writer).writeSshKey(any(), any(), any(), any(), any(), any());
+  }
+}


### PR DESCRIPTION
## Summary
- add SshKeyService and SshKeysResource to list, create, and delete SSH key credentials per user
- extend CredentialStore with list/remove helpers and document new REST API
- return 404 when validating a non-existent SSH credential

## Testing
- `./mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a156696330832d9843d2955bd4ea94