### PR TITLE
feat(security): integrate Keycloak OIDC and drop custom headers

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -58,18 +58,17 @@ services:
       KC_DB_URL_DATABASE: tasktally
       KC_DB_USERNAME: tasktally
       KC_DB_PASSWORD: tasktally
-      KC_HTTP_PORT: 8081
       KEYCLOAK_ADMIN: admin
       KEYCLOAK_ADMIN_PASSWORD: admin
     ports:
-      - "8081:8081"
+      - "8080:8080"
     depends_on:
       - postgres
-    command: start-dev --http-port=8081
+    command: start-dev
     volumes:
       - ./init-keycloak.sh:/opt/keycloak/init-keycloak.sh
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8081/health/ready"]
+      test: ["CMD", "curl", "-f", "http://localhost:8080/health/ready"]
       interval: 5s
       timeout: 3s
       retries: 20

--- a/init-keycloak.sh
+++ b/init-keycloak.sh
@@ -1,23 +1,42 @@
 #!/bin/bash
 
 # Wait for Keycloak to be ready
-until curl -s http://localhost:8080/health/ready | grep '"status":"UP"' > /dev/null; do
+until curl -sf http://keycloak:8080/health/ready | grep '"status":"UP"' > /dev/null; do
   echo "Waiting for Keycloak to be ready..."
-  sleep 5
+  sleep 3
 done
 
 # Login to Keycloak
-/opt/keycloak/bin/kcadm.sh config credentials --server http://localhost:8080 --realm master --user admin --password admin
+/opt/keycloak/bin/kcadm.sh config credentials --server http://keycloak:8080 --realm master --user "$KEYCLOAK_ADMIN" --password "$KEYCLOAK_ADMIN_PASSWORD"
 
-# Create the client
-/opt/keycloak/bin/kcadm.sh create clients -r master -s clientId=task-tally-client \
-  -s enabled=true \
-  -s publicClient=true \
-  -s protocol=openid-connect \
-  -s 'redirectUris=["http://localhost:9000/*"]' \
-  -s 'webOrigins=["http://localhost:9000"]' \
-  -s standardFlowEnabled=true \
-  -s attributes.'pkce.code.challenge.method'="S256" \
-  -s attributes.'pkce.code.challenge.required'="true"
+REALM=tasktally
+KC=http://keycloak:8080
 
-echo "Keycloak client initialized."
+# Create realm
+/opt/keycloak/bin/kcadm.sh create realms -s realm=$REALM -s enabled=true || true
+
+# Backend service client
+auth_backend="clients -r $REALM -s clientId=task-tally-backend -s enabled=true -s protocol=openid-connect -s publicClient=false -s serviceAccountsEnabled=true -s standardFlowEnabled=false -s directAccessGrantsEnabled=false"
+/opt/keycloak/bin/kcadm.sh create $auth_backend || true
+
+# Swagger public client with PKCE
+/opt/keycloak/bin/kcadm.sh create clients -r $REALM -s clientId=task-tally-swagger -s enabled=true -s protocol=openid-connect -s publicClient=true -s standardFlowEnabled=true -s 'attributes."pkce.code.challenge.method"=S256' -s 'attributes."pkce.code.challenge.required"=true' -s 'redirectUris=["http://localhost:8080/q/swagger-ui/oauth2-redirect.html"]' -s 'webOrigins=["http://localhost:8080"]' || true
+
+SWAGGER_ID=$(/opt/keycloak/bin/kcadm.sh get clients -r $REALM -q clientId=task-tally-swagger --fields id --format csv --noquotes)
+/opt/keycloak/bin/kcadm.sh create clients/$SWAGGER_ID/protocol-mappers/models -r $REALM -s name=aud-task-tally-backend -s protocol=openid-connect -s protocolMapper=oidc-audience-mapper -s 'config."included.client.audience"=task-tally-backend' -s 'config."id.token.claim"=false' -s 'config."access.token.claim"=true' || true
+
+# Roles
+/opt/keycloak/bin/kcadm.sh create roles -r $REALM -s name=user || true
+/opt/keycloak/bin/kcadm.sh create roles -r $REALM -s name=admin || true
+
+# Users
+for u in alice admin; do
+  /opt/keycloak/bin/kcadm.sh create users -r $REALM -s username=$u -s enabled=true || true
+  /opt/keycloak/bin/kcadm.sh set-password -r $REALM --username $u --new-password $u
+ done
+
+/opt/keycloak/bin/kcadm.sh add-roles -r $REALM --uusername alice --rolename user
+/opt/keycloak/bin/kcadm.sh add-roles -r $REALM --uusername admin --rolename user
+/opt/keycloak/bin/kcadm.sh add-roles -r $REALM --uusername admin --rolename admin
+
+echo "Keycloak realm initialized."

--- a/pom.xml
+++ b/pom.xml
@@ -76,6 +76,14 @@
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-rest-jackson</artifactId>
     </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-oidc</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-security</artifactId>
+    </dependency>
     <!-- Swagger UI / OpenAPI for Quarkus -->
     <dependency>
       <groupId>io.quarkus</groupId>

--- a/src/main/java/io/redhat/na/ssp/tasktally/api/ApiSecurity.java
+++ b/src/main/java/io/redhat/na/ssp/tasktally/api/ApiSecurity.java
@@ -1,0 +1,22 @@
+package io.redhat.na.ssp.tasktally.api;
+
+import io.swagger.v3.oas.annotations.enums.SecuritySchemeType;
+import io.swagger.v3.oas.annotations.security.OAuthFlow;
+import io.swagger.v3.oas.annotations.security.OAuthFlows;
+import io.swagger.v3.oas.annotations.security.OAuthScope;
+import io.swagger.v3.oas.annotations.security.SecurityScheme;
+
+@SecurityScheme(
+  name = "keycloak",
+  type = SecuritySchemeType.OAUTH2,
+  flows = @OAuthFlows(
+    authorizationCode = @OAuthFlow(
+      authorizationUrl = "http://localhost:8080/realms/tasktally/protocol/openid-connect/auth",
+      tokenUrl = "http://localhost:8080/realms/tasktally/protocol/openid-connect/token",
+      scopes = {
+        @OAuthScope(name = "openid", description = "OpenID Connect")
+      }
+    )
+  )
+)
+public class ApiSecurity {}

--- a/src/main/java/io/redhat/na/ssp/tasktally/security/Identities.java
+++ b/src/main/java/io/redhat/na/ssp/tasktally/security/Identities.java
@@ -1,0 +1,11 @@
+package io.redhat.na.ssp.tasktally.security;
+
+import io.quarkus.security.identity.SecurityIdentity;
+
+public final class Identities {
+  private Identities() {}
+
+  public static String userId(SecurityIdentity identity) {
+    return identity.getPrincipal().getName();
+  }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -15,3 +15,24 @@ quarkus.swagger-ui.title=Task Tally API Docs
 quarkus.vault.url=${VAULT_URL:http://localhost:8200}
 quarkus.vault.authentication=${VAULT_AUTHENTICATION:token}
 quarkus.vault.token=${VAULT_TOKEN:my-token}
+
+# OIDC / Keycloak
+quarkus.oidc.auth-server-url=http://localhost:8080/realms/tasktally
+quarkus.oidc.application-type=service
+quarkus.oidc.token.audience=task-tally-backend
+
+quarkus.http.auth.permission.public.paths=/q/health/*,/q/openapi,/q/swagger-ui/*
+quarkus.http.auth.permission.public.policy=permit
+quarkus.http.auth.permission.authenticated.paths=/api/*
+quarkus.http.auth.permission.authenticated.policy=authenticated
+
+quarkus.http.cors=true
+quarkus.http.cors.origins=http://localhost:8080
+
+# Swagger UI OAuth config
+quarkus.swagger-ui.oauth2-redirect-url=http://localhost:8080/q/swagger-ui/oauth2-redirect.html
+quarkus.swagger-ui.oauth-client-id=task-tally-swagger
+quarkus.swagger-ui.oauth-use-pkce-with-authorization-code-grant=true
+quarkus.swagger-ui.oauth-app-name=Task Tally Swagger
+quarkus.swagger-ui.persist-authorization=true
+

--- a/src/test/java/io/redhat/na/ssp/tasktally/api/SshKeysResourceTest.java
+++ b/src/test/java/io/redhat/na/ssp/tasktally/api/SshKeysResourceTest.java
@@ -8,6 +8,7 @@ import static org.mockito.Mockito.when;
 
 import io.quarkus.test.InjectMock;
 import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.security.TestSecurity;
 import io.redhat.na.ssp.tasktally.secrets.SecretWriter;
 import io.redhat.na.ssp.tasktally.secrets.SshSecretRefs;
 import org.junit.jupiter.api.BeforeEach;
@@ -16,12 +17,9 @@ import org.junit.jupiter.api.Test;
 @QuarkusTest
 public class SshKeysResourceTest {
   private void cleanupUserKeys(String userId) {
-    // Get all keys for the user
-    var response = given().header("X-User-Id", userId).get("/api/users/" + userId + "/ssh-keys").then().extract()
-        .jsonPath().getList("name");
-    // Delete each key
+    var response = given().get("/api/users/" + userId + "/ssh-keys").then().extract().jsonPath().getList("name");
     for (Object key : response) {
-      given().header("X-User-Id", userId).delete("/api/users/" + userId + "/ssh-keys/" + key).then().statusCode(204);
+      given().delete("/api/users/" + userId + "/ssh-keys/" + key).then().statusCode(204);
     }
   }
 
@@ -32,41 +30,47 @@ public class SshKeysResourceTest {
   public void setup() {
     when(writer.writeSshKey(any(), any(), any(), any(), any(), any()))
         .thenReturn(new SshSecretRefs("kref", "href", null));
-    cleanupUserKeys("u1");
   }
 
   @Test
+  @TestSecurity(user = "u1", roles = {"user"})
   public void createListDelete() {
-    String body = "{\"name\":\"k1\",\"provider\":\"github\",\"privateKeyPem\":\"-----BEGIN OPENSSH PRIVATE KEY-----\\nAAA\\n-----END OPENSSH PRIVATE KEY-----\\n\",\"knownHosts\":\"github.com ssh-ed25519 AAAA\\n\"}";
-    given().header("X-User-Id", "u1").contentType("application/json").body(body).post("/api/users/u1/ssh-keys").then()
+    cleanupUserKeys("u1");
+    String body = "{\"name\":\"k1\",\"provider\":\"github\",\"privateKeyPem\":\"-----BEGIN OPENSSH PRIVATE KEY-----\\nAAA\\n----END OPENSSH PRIVATE KEY-----\\n\",\"knownHosts\":\"github.com ssh-ed25519 AAAA\\n\"}";
+    given().contentType("application/json").body(body).post("/api/users/u1/ssh-keys").then()
         .statusCode(201).body("secretRef", equalTo("kref"));
-    given().header("X-User-Id", "u1").get("/api/users/u1/ssh-keys").then().statusCode(200).body("", hasSize(1));
-    given().header("X-User-Id", "u1").delete("/api/users/u1/ssh-keys/k1").then().statusCode(204);
-    given().header("X-User-Id", "u1").get("/api/users/u1/ssh-keys").then().statusCode(200).body("", hasSize(0));
+    given().get("/api/users/u1/ssh-keys").then().statusCode(200).body("", hasSize(1));
+    given().delete("/api/users/u1/ssh-keys/k1").then().statusCode(204);
+    given().get("/api/users/u1/ssh-keys").then().statusCode(200).body("", hasSize(0));
   }
 
   @Test
+  @TestSecurity(user = "u1", roles = {"user"})
   public void duplicateName409() {
-    String body = "{\"name\":\"dup\",\"provider\":\"github\",\"privateKeyPem\":\"-----BEGIN OPENSSH PRIVATE KEY-----\\nAAA\\n-----END OPENSSH PRIVATE KEY-----\\n\"}";
-    given().header("X-User-Id", "u1").contentType("application/json").body(body).post("/api/users/u1/ssh-keys").then()
-        .statusCode(201);
-    given().header("X-User-Id", "u1").contentType("application/json").body(body).post("/api/users/u1/ssh-keys").then()
-        .statusCode(409);
+    cleanupUserKeys("u1");
+    String body = "{\"name\":\"dup\",\"provider\":\"github\",\"privateKeyPem\":\"-----BEGIN OPENSSH PRIVATE KEY-----\\nAAA\\n----END OPENSSH PRIVATE KEY-----\\n\"}";
+    given().contentType("application/json").body(body).post("/api/users/u1/ssh-keys").then().statusCode(201);
+    given().contentType("application/json").body(body).post("/api/users/u1/ssh-keys").then().statusCode(409);
   }
 
   @Test
+  @TestSecurity(user = "u1", roles = {"user"})
   public void oversizedKey400() {
     String big = "A".repeat(11 * 1024);
-    String body = "{\"name\":\"big\",\"provider\":\"github\",\"privateKeyPem\":\"-----BEGIN OPENSSH PRIVATE KEY-----"
-        + big + "-----END OPENSSH PRIVATE KEY-----\"}";
-    given().header("X-User-Id", "u1").contentType("application/json").body(body).post("/api/users/u1/ssh-keys").then()
-        .statusCode(400);
+    String body = "{\"name\":\"big\",\"provider\":\"github\",\"privateKeyPem\":\"-----BEGIN OPENSSH PRIVATE KEY-----" +
+        big + "-----END OPENSSH PRIVATE KEY-----\"}";
+    given().contentType("application/json").body(body).post("/api/users/u1/ssh-keys").then().statusCode(400);
   }
 
   @Test
-  public void headerMismatch403() {
-    String body = "{\"name\":\"k2\",\"provider\":\"github\",\"privateKeyPem\":\"-----BEGIN OPENSSH PRIVATE KEY-----\\nAAA\\n-----END OPENSSH PRIVATE KEY-----\\n\"}";
-    given().header("X-User-Id", "u2").contentType("application/json").body(body).post("/api/users/u1/ssh-keys").then()
-        .statusCode(403);
+  @TestSecurity(user = "u2", roles = {"user"})
+  public void pathMismatch403() {
+    String body = "{\"name\":\"k2\",\"provider\":\"github\",\"privateKeyPem\":\"-----BEGIN OPENSSH PRIVATE KEY-----\\nAAA\\n----END OPENSSH PRIVATE KEY-----\\n\"}";
+    given().contentType("application/json").body(body).post("/api/users/u1/ssh-keys").then().statusCode(403);
+  }
+
+  @Test
+  public void missingToken401() {
+    given().get("/api/users/u1/ssh-keys").then().statusCode(401);
   }
 }

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -1,7 +1,1 @@
-quarkus.datasource.db-kind=postgresql
-#quarkus.datasource.jdbc.url=jdbc:tc:postgresql:16:///tasktally
-quarkus.datasource.username=test
-quarkus.datasource.password=test
-quarkus.flyway.migrate-at-start=true
-
-quarkus.flyway.locations=db/migration
+quarkus.oidc.enabled=false


### PR DESCRIPTION
## Summary
- secure /api/* with Keycloak OIDC bearer tokens
- replace X-User-Id header with SecurityIdentity across resources
- wire Swagger-UI OAuth2 Authorize button and document token usage

## Testing
- `./mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a25feff3e8832dae645e233eb85ff4