### PR TITLE
feat: support encrypted ssh key generation

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -44,3 +44,6 @@ quarkus.swagger-ui.oauth-use-pkce-with-authorization-code-grant=true
 quarkus.swagger-ui.oauth-app-name=Task Tally Swagger
 quarkus.swagger-ui.persist-authorization=true
 
+ssh.kdf.rounds=16
+ssh.encryption.required=false
+

--- a/src/test/java/io/redhat/na/ssp/tasktally/secrets/KubernetesSecretWriterTest.java
+++ b/src/test/java/io/redhat/na/ssp/tasktally/secrets/KubernetesSecretWriterTest.java
@@ -28,5 +28,9 @@ public class KubernetesSecretWriterTest {
     assertArrayEquals(priv, resolved);
     assertEquals("k8s:secret/tasktally-ssh-u1-my-key#id_ed25519", refs.privateKeyRef());
     assertEquals("k8s:secret/tasktally-ssh-u1-my-key#known_hosts", refs.knownHostsRef());
+    String pubFile = Files.readString(base.resolve("tasktally-ssh-u1-my-key").resolve("id_ed25519.pub"));
+    assertTrue(pubFile.endsWith("\n"));
+    String khFile = Files.readString(base.resolve("tasktally-ssh-u1-my-key").resolve("known_hosts"));
+    assertTrue(khFile.endsWith("\n"));
   }
 }

--- a/src/test/java/io/redhat/na/ssp/tasktally/service/SshKeyServiceTest.java
+++ b/src/test/java/io/redhat/na/ssp/tasktally/service/SshKeyServiceTest.java
@@ -4,14 +4,20 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import io.quarkus.test.InjectMock;
 import io.quarkus.test.junit.QuarkusTest;
 import io.redhat.na.ssp.tasktally.api.SshKeyCreateRequest;
+import io.redhat.na.ssp.tasktally.api.SshKeyGenerateRequest;
 import io.redhat.na.ssp.tasktally.model.CredentialRef;
+import io.redhat.na.ssp.tasktally.secret.SecretResolver;
 import io.redhat.na.ssp.tasktally.secrets.SecretWriter;
 import io.redhat.na.ssp.tasktally.secrets.SshSecretRefs;
 import jakarta.inject.Inject;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.atomic.AtomicReference;
 import org.junit.jupiter.api.Test;
 
 @QuarkusTest
@@ -23,6 +29,8 @@ public class SshKeyServiceTest {
   CredentialStore store;
   @InjectMock
   SecretWriter writer;
+  @InjectMock
+  SecretResolver resolver;
 
   @Test
   public void createStoresCredential() {
@@ -37,5 +45,59 @@ public class SshKeyServiceTest {
     assertEquals("ref1", cred.secretRef);
     assertEquals(1, store.list("u1").size());
     verify(writer).writeSshKey(any(), any(), any(), any(), any(), any());
+  }
+
+  @Test
+  public void generateWithoutPassphrase() {
+    AtomicReference<byte[]> priv = new AtomicReference<>();
+    AtomicReference<byte[]> pub = new AtomicReference<>();
+    when(writer.writeSshKey(any(), any(), any(), any(), any(), any())).thenAnswer(inv -> {
+      priv.set(inv.getArgument(2));
+      pub.set(inv.getArgument(3));
+      return new SshSecretRefs("k8s:secret/tasktally-ssh-u1-k1#id_ed25519", null, null);
+    });
+    when(resolver.resolveBytes(any())).thenAnswer(inv -> pub.get());
+
+    SshKeyGenerateRequest req = new SshKeyGenerateRequest();
+    req.name = "k1";
+    req.provider = "github";
+    CredentialRef cred = service.generate("u1", req);
+    assertNotNull(cred);
+    String pk = service.getPublicKey("u1", "k1");
+    assertTrue(pk.startsWith("ssh-ed25519 "));
+    String privStr = new String(priv.get(), StandardCharsets.UTF_8);
+    assertTrue(privStr.contains("openssh-key-v1"));
+  }
+
+  @Test
+  public void generateWithPassphraseEncrypted() {
+    AtomicReference<byte[]> priv = new AtomicReference<>();
+    when(writer.writeSshKey(any(), any(), any(), any(), any(), any())).thenAnswer(inv -> {
+      priv.set(inv.getArgument(2));
+      return new SshSecretRefs("ref", null, null);
+    });
+    SshKeyGenerateRequest req = new SshKeyGenerateRequest();
+    req.name = "enc";
+    req.provider = "github";
+    req.passphrase = "test";
+    service.generate("u1", req);
+    String privStr = new String(priv.get(), StandardCharsets.UTF_8);
+    assertTrue(privStr.contains("aes256-ctr"));
+  }
+
+  @Test
+  public void knownHostsEndsWithNewline() {
+    AtomicReference<byte[]> kh = new AtomicReference<>();
+    when(writer.writeSshKey(any(), any(), any(), any(), any(), any())).thenAnswer(inv -> {
+      kh.set(inv.getArgument(5));
+      return new SshSecretRefs("ref", "khref", null);
+    });
+    SshKeyGenerateRequest req = new SshKeyGenerateRequest();
+    req.name = "kh";
+    req.provider = "github";
+    req.knownHosts = "github.com ssh-ed25519 AAAA";
+    service.generate("u1", req);
+    assertNotNull(kh.get());
+    assertEquals('\n', kh.get()[kh.get().length - 1]);
   }
 }


### PR DESCRIPTION
## Summary
- support optional passphrase encryption for generated SSH keys
- ensure Kubernetes writer stores public and known_hosts files with trailing newlines
- improve error responses and public key retrieval

## Testing
- `./mvnw -q test` *(fails: Network is unreachable)*
- `./pre-commit.sh` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a38de3ebc4832d8d967fe2f0385b66