### PR TITLE
fix: use default Ed25519 provider with fallback

### DIFF
--- a/src/main/java/io/redhat/na/ssp/tasktally/service/SshKeyService.java
+++ b/src/main/java/io/redhat/na/ssp/tasktally/service/SshKeyService.java
@@ -136,7 +136,13 @@ public class SshKeyService {
     }
 
     try {
-      KeyPairGenerator kpg = KeyPairGenerator.getInstance("Ed25519", "EdDSA");
+      KeyPairGenerator kpg;
+      try {
+        kpg = KeyPairGenerator.getInstance("Ed25519");
+      } catch (GeneralSecurityException ignore) {
+        // fallback to EdDSA provider if default not available
+        kpg = KeyPairGenerator.getInstance("Ed25519", "EdDSA");
+      }
       KeyPair kp = kpg.generateKeyPair();
       byte[] privateOpenSsh = writeOpenSshPrivateKey(kp, req.passphrase);
 


### PR DESCRIPTION
## Summary
- ensure SSH key generation uses the JVM's default Ed25519 provider and fallback to EdDSA

## Testing
- `mvn spotless:apply` *(fails: dependencies could not be resolved, network is unreachable)*
- `mvn test` *(fails: dependencies could not be resolved, network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a3a7e4ca14832d9742639802ae5828